### PR TITLE
Feat: Add CD pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 **/__pycache__
 venv
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/__pycache__
 venv
 .github
+scraper/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,100 @@
+---
+name: Build and Deploy to AWS
+"on":
+  push:
+    branches: [main]
+
+env:
+  API_IMAGE: ghcr.io/ias-tcd/competitor-matching-api/api
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout main
+        uses: actions/checkout@v4
+
+      - name: Set environment variables to .env
+        run: |
+          echo "API_IMAGE=$(echo ${{env.API_IMAGE}} )" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Packages
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: echo ${PERSONAL_ACCESS_TOKEN} | docker login ghcr.io -u ${{ secrets.NAMESPACE }} --password-stdin
+
+      - name: Pull images
+        run: |
+          docker pull ${{ env.API_IMAGE }} || true
+
+      - name: Build images
+        env:
+          SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          HOST_IP_ADDRESS: ${{ secrets.AWS_EC2_IP_ADDRESS }}
+        run: |
+          touch .env
+          docker-compose --env-file ./.env -f docker/docker-compose.prod.yml build
+
+      - name: Push images
+        run: |
+          docker push ${{ env.API_IMAGE }}
+
+  checking-secrets:
+    name: Checking secrets
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      secret_key_exists: ${{steps.check_secrets.outputs.defined}}
+    steps:
+      - name: Check for Secrets availabilities
+        id: check_secrets
+        shell: bash
+        run: |
+          if [[ -n "${{ secrets.PRIVATE_KEY }}" && -n "${{secrets.AWS_EC2_IP_ADDRESS}}" && -n "${{secrets.AWS_HOST_USER}}" ]]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
+  deploy:
+    name: Deploy to AWS EC2
+    runs-on: ubuntu-latest
+    needs: checking-secrets
+    if: needs.checking-secrets.outputs.secret_key_exists == 'true'
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Add environment variables to .env
+        run: |
+          echo API_IMAGE=${{ env.API_IMAGE }} >> .env
+          echo NAMESPACE=${{ secrets.NAMESPACE }} >> .env
+          echo PERSONAL_ACCESS_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .env
+
+      - name: Add the private SSH key to the ssh-agent
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          mkdir -p ~/.ssh
+          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          ssh-add - <<< "${{ secrets.PRIVATE_KEY }}"
+
+      - name: Deploy image on AWS EC2
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
+        run: |
+          scp -o StrictHostKeyChecking=no -r ./.env ./docker/docker-compose.prod.yml ${{secrets.AWS_HOST_USER}}@${{ secrets.AWS_EC2_IP_ADDRESS }}:
+          ssh -o StrictHostKeyChecking=no ${{secrets.AWS_HOST_USER}}@${{ secrets.AWS_EC2_IP_ADDRESS }} << EOF
+              set -e
+              docker-compose -f docker-compose.prod.yml down --rmi all -v
+              docker login ghcr.io -u ${{secrets.NAMESPACE}} -p ${{secrets.PERSONAL_ACCESS_TOKEN}}
+              docker pull $API_IMAGE
+              docker-compose -f docker-compose.prod.yml run api python api/manage.py migrate
+              docker-compose --env-file ./.env -f docker-compose.prod.yml up -d
+              docker logout
+          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ name: Build and Deploy to AWS
     branches: [main]
 
 env:
-  API_IMAGE: ghcr.io/ias-tcd/competitor-matching-api/api
+  API_IMAGE: ghcr.io/ias-tcd/competitor-matching-model/api
+  NGINX_IMAGE: ghcr.io/ias-tcd/competitor-matching-model/nginx
   REGISTRY: ghcr.io
 
 jobs:
@@ -20,6 +21,7 @@ jobs:
       - name: Set environment variables to .env
         run: |
           echo "API_IMAGE=$(echo ${{env.API_IMAGE}} )" >> $GITHUB_ENV
+          echo "NGINX_IMAGE=$(echo ${{env.NGINX_IMAGE}} )" >> $GITHUB_ENV
 
       - name: Log in to GitHub Packages
         env:
@@ -29,18 +31,23 @@ jobs:
       - name: Pull images
         run: |
           docker pull ${{ env.API_IMAGE }} || true
+          docker pull ${{ env.NGINX_IMAGE }} || true
 
       - name: Build images
         env:
           SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
           HOST_IP_ADDRESS: ${{ secrets.AWS_EC2_IP_ADDRESS }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
         run: |
-          touch .env
+          echo "DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}" >> .env
           docker-compose --env-file ./.env -f docker/docker-compose.prod.yml build
 
       - name: Push images
         run: |
           docker push ${{ env.API_IMAGE }}
+          docker push ${{ env.NGINX_IMAGE }}
 
   checking-secrets:
     name: Checking secrets
@@ -71,8 +78,15 @@ jobs:
       - name: Add environment variables to .env
         run: |
           echo API_IMAGE=${{ env.API_IMAGE }} >> .env
+          echo NGINX_IMAGE=${{ env.NGINX_IMAGE }} >> .env
           echo NAMESPACE=${{ secrets.NAMESPACE }} >> .env
           echo PERSONAL_ACCESS_TOKEN=${{ secrets.PERSONAL_ACCESS_TOKEN }} >> .env
+          echo SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}" >> .env
+          echo POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} >> .env
+          echo POSTGRES_USER=${{ secrets.POSTGRES_USER }} >> .env
+          echo POSTGRES_DB=${{ secrets.POSTGRES_DB }} >> .env
+          echo DATABASE_URL=postgres://${{ secrets.POSTGRES_USER }}:${{ secrets.POSTGRES_PASSWORD }}@db:5432/${{ secrets.POSTGRES_DB }} >> .env
+          echo FRONTEND_URL=${{ secrets.FRONTEND_URL }} >> .env
 
       - name: Add the private SSH key to the ssh-agent
         env:
@@ -88,13 +102,13 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
         run: |
-          scp -o StrictHostKeyChecking=no -r ./.env ./docker/docker-compose.prod.yml ${{secrets.AWS_HOST_USER}}@${{ secrets.AWS_EC2_IP_ADDRESS }}:
+          scp -o StrictHostKeyChecking=no -r ./docker/entrypoint.sh ./.env ./docker/docker-compose.prod.yml ${{secrets.AWS_HOST_USER}}@${{ secrets.AWS_EC2_IP_ADDRESS }}:
           ssh -o StrictHostKeyChecking=no ${{secrets.AWS_HOST_USER}}@${{ secrets.AWS_EC2_IP_ADDRESS }} << EOF
               set -e
-              docker-compose -f docker-compose.prod.yml down --rmi all -v
               docker login ghcr.io -u ${{secrets.NAMESPACE}} -p ${{secrets.PERSONAL_ACCESS_TOKEN}}
               docker pull $API_IMAGE
-              docker-compose -f docker-compose.prod.yml run api python api/manage.py migrate
-              docker-compose --env-file ./.env -f docker-compose.prod.yml up -d
+              docker pull $NGINX_IMAGE
               docker logout
+              docker-compose -f docker-compose.prod.yml down --rmi all
+              sh entrypoint.sh
           EOF

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pip install -r requirements.local.txt
 pre-commit install
 
 # Add an environment file (this can be populated later)
-touch .env
+echo FRONTEND_URL=http://localhost:5173 > .env
 
 # Build the docker container
 make build
@@ -61,6 +61,12 @@ brew install git-lfs
 # After installation
 git lfs install
 ```
+
+## Deployments
+
+This API is deployed to AWS using Docker and GitHub Actions. The API can be accessed at the following [url](http://3.254.180.26).
+In the `/docker` directory you will find `entrypoint.sh` and `docker-compose.prod.yml`. Alongside the deployment script in `.github/workflows/deploy.yml`, this builds a slim version of the API image and pushes the image to the GitHub Container Registry. These images are pulled down in the AWS EC2 instance and used to spin up the containers.
+There are three production containers: `api`, `db` and `nginx`. `api` is used to receive REST requests from our front end client and uses the `db` to persist information. Django (the framework this API is built in) also provides a powerful admin interface which must be served statically. We use `nginx` here to both serve the static files and pass requests to the API.
 
 ## Useful Commands
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -28,6 +28,7 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
+    "*",
 ]
 
 INTERNAL_IPS = ["127.0.0.1", "172.20.0.1"]

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -128,7 +128,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # Default primary key field type

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,4 +26,6 @@ WORKDIR /src
 
 COPY .. /src/
 
+RUN mkdir ./api/staticfiles/
+
 RUN python api/manage.py collectstatic --no-input

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -3,14 +3,21 @@ version: "3.8"
 
 services:
   api:
+    image: "${API_IMAGE}"
+    working_dir: /src/api
     command: gunicorn api.wsgi:application --bind 0.0.0.0:8000
     build:
       context: ..
       dockerfile: docker/Dockerfile
     environment:
       - ENV=production
+      - SECRET_KEY="${SECRET_KEY}"
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - DATABASE_URL=${DATABASE_URL}
     volumes:
-      - static_volume:/home/src/api/staticfiles
+      - static_volume:/src/api/staticfiles
     expose:
       - 8000
     depends_on:
@@ -18,15 +25,20 @@ services:
 
   db:
     image: postgres:16.1-alpine
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
   nginx:
+    image: "${NGINX_IMAGE}"
     build: ../nginx
     volumes:
-      - static_volume:/home/src/web/staticfiles
+      - static_volume:/src/api/staticfiles
     ports:
-      - "1337:80"
+      - "80:80"
     depends_on:
       - api
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+---
+version: "3.8"
+
+services:
+  api:
+    command: gunicorn api.wsgi:application --bind 0.0.0.0:8000
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    environment:
+      - ENV=production
+    volumes:
+      - static_volume:/home/src/api/staticfiles
+    expose:
+      - 8000
+    depends_on:
+      - db
+
+  db:
+    image: postgres:16.1-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  nginx:
+    build: ../nginx
+    volumes:
+      - static_volume:/home/src/web/staticfiles
+    ports:
+      - "1337:80"
+    depends_on:
+      - api
+
+volumes:
+  postgres_data:
+  static_volume:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+docker-compose --env-file ./.env -f docker-compose.prod.yml run api python manage.py migrate
+docker-compose --env-file ./.env -f docker-compose.prod.yml up -d
+docker system prune -af

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.25
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/conf.d

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,5 +1,5 @@
 upstream api {
-    server web:8000;
+    server api:8000;
 }
 
 server {
@@ -14,7 +14,7 @@ server {
     }
 
     location /static/ {
-        alias /home/src/api/staticfiles/;
+        alias /src/api/staticfiles/;
     }
 
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,20 @@
+upstream api {
+    server web:8000;
+}
+
+server {
+
+    listen 80;
+
+    location / {
+        proxy_pass http://api;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+    location /static/ {
+        alias /home/src/api/staticfiles/;
+    }
+
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ django-cors-headers==4.3.1
 django-log-request-id==2.1.0
 django-request-logging==0.7.5
 djangorestframework==3.14.0
+gunicorn>=21.2,<21.3
 psycopg2==2.9.9
 requests==2.31.0
 whitenoise==6.6.0


### PR DESCRIPTION
Adds a github actions CD pipeline to build and deploy the API to an AWS EC2 instance.

This involves building the docker images for the API and an nginx configuration, pushing them to the GitHub container registry and ssh-ing into the EC2 instance to pull down the latest image and deploy it.

The nginx configuration is used to serve the static files provided by django which allow access to the admin panel. I've also docker-ignored large directories that don't need to be used in production to build a lighter image.