### PR TITLE
Chore: Bump Django and OpenCV versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-log-request-id==2.1.0
 django-request-logging==0.7.5
 djangorestframework==3.14.0
 gunicorn>=21.2,<21.3
-opencv-python>=4.1.1.26
+opencv-python>=4.1.1.26, !=4.9.0.80
 pillow~=10.2.0
 psycopg2==2.9.9
 requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==2.1.0
-Django==5.0.1
+Django~=5.0
 django-cors-headers==4.3.1
 django-log-request-id==2.1.0
 django-request-logging==0.7.5


### PR DESCRIPTION
* Bumps Django version to 5.0.2 (latest) to avoid [this issue](https://github.com/ias-tcd/competitor-matching-model/security/dependabot/1)
* Restricts opencv-python version to avoid [this vulnerability](https://devhub.checkmarx.com/cve-details/CVE-2019-9423/)