### PR TITLE
Bugfix: Fix arbitrary CI test failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,13 +10,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build
-        run: |
-          touch .env
-          make build
+      - name: Create .env file
+        run: touch .env
 
       - name: Start Database
         run: docker-compose -f docker/docker-compose.local.yml up --build -d db
+
+      - name: Build
+        run: make build
 
       - name: Test
         run: make test


### PR DESCRIPTION
The CI was failing arbitrarily if the database service did not start up in time before the tests were executed, despite the `api` service depending on the `db` service. This fix starts the database before the build phase of the `api` service, meaning that the database should be listening for connections by the time the test phase starts since the build phase typically lasts 1.5 - 2 minutes.