### PR TITLE
Chore: Hide LFS migration from blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# moving from LFS tracking to regular tracking for images
+16ecc833f358b167f2250df5ae11d1551e0b6eda

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ brew install git-lfs
 git lfs install
 ```
 
+Due to the GitHub organisation being a free organisation, we are somewhat limited by the number of files we can track using git LFS.
+So we had to revert to tracking images with regular git tracking and save LFS for the weights files.
+This overwrote the git history, so to clean this up, we have provided a `.git-blame-ignore-revs` file to be used if checking for commit authors.
+So instead of `git blame <file-name>`, you can use `git blame <file-name> --ignore-revs-file=.git-blame-ignore-revs` to see the cleaner history.
+
 ## Running an individual model
 
 You may want to run custom or specific code on a given model without the API for local testing.


### PR DESCRIPTION
Hides the LFS migration made in #102 from git blame